### PR TITLE
Display the IP address on the LCD

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -58,7 +58,7 @@
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "env": {
-        "DEBUG": "openevse*"
+        "DEBUG": "openevse,openevse:lcd*"
       },
       "args": [
         "--lcd", "rapi"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,6 +49,20 @@
       "args": [
         "--endpoint", "/dev/ttyUSB0"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch OpenEVSE (LCD RAPI)",
+      "program": "${workspaceFolder}/src/app.js",
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "env": {
+        "DEBUG": "openevse*"
+      },
+      "args": [
+        "--lcd", "rapi"
+      ]
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2227,8 +2227,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2249,14 +2248,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2271,20 +2268,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2401,8 +2395,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2414,7 +2407,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2429,7 +2421,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2437,14 +2428,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2463,7 +2452,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2544,8 +2532,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2557,7 +2544,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2643,8 +2629,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2680,7 +2665,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2700,7 +2684,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2744,14 +2727,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -551,8 +551,7 @@
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.1",
@@ -2901,6 +2900,11 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -4101,10 +4105,50 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-1.1.2.tgz",
+      "integrity": "sha1-0oQaElv9dP77MMA0QQQ2kGHD4To=",
+      "requires": {
+        "debug": "^2.1.2",
+        "iconv-lite": "^0.4.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "network": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/network/-/network-0.4.1.tgz",
+      "integrity": "sha1-MLtNQbYkBypNqZBDH3dRNhLEXMA=",
+      "requires": {
+        "async": "^1.5.2",
+        "commander": "2.9.0",
+        "needle": "1.1.2",
+        "wmic": "^0.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        }
+      }
     },
     "next-tick": {
       "version": "1.0.0",
@@ -6438,6 +6482,25 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
             "kind-of": "^3.0.2"
+          }
+        }
+      }
+    },
+    "wmic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wmic/-/wmic-0.1.0.tgz",
+      "integrity": "sha1-eLQasR0VTLgSgZ4SkWdNrVXY4dc=",
+      "requires": {
+        "async": "^2.6.2",
+        "iconv-lite": "^0.4.13"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "express-ws": "^4.0.0",
     "minimist": "^1.2.0",
     "mqtt": "^2.18.0",
+    "network": "^0.4.1",
     "ohmhour": "^1.0.0",
     "openevse": "^1.0.1",
     "openevse_wifi_gui": "^1.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@
 const minimist = require("minimist");
 const OpenEVSEWiFi = require("./openevsewifi");
 const web = require("./web");
+const debug = require("debug")("openevse:app");
 
 var app = new OpenEVSEWiFi();
 
@@ -16,9 +17,12 @@ let args = minimist(process.argv.slice(2), {
     help: false,
     version: false,
     port: 3000,
-    endpoint: "simulator"
+    endpoint: "simulator",
+    lcd: false
   },
 });
+
+debug(args);
 
 if(args.help) {
   console.log("OpenEVSE WiFi Simulator");
@@ -32,3 +36,10 @@ if(args.version) {
 
 app.start(args.endpoint);
 web.start(app, args.port);
+
+if(args.lcd)
+{
+  const lcd = require("./lcd");
+  var lcdApp = new lcd();
+  lcdApp.start(app, args.lcd);
+}

--- a/src/lcd.js
+++ b/src/lcd.js
@@ -1,0 +1,35 @@
+/* jshint node: true, esversion: 6*/
+
+"use strict";
+
+module.exports = class
+{
+  constructor()
+  {
+  }
+
+  start(app, driver)
+  {
+    this.app = app;
+
+    // TODO extend to support different LCD drivers, eg I2C directly
+    if("rapi" === driver.toLowerCase()) {
+      const lcdDriver = require("./lcdrapi");
+      this.lcd = new lcdDriver();
+    } else {
+      throw "Unknown LCD driver "+driver;
+    }
+
+    app.on("boot", () => {
+      this.lcd.display("OpenEVSE WiFi", 0, 0, { clear: true });
+      this.lcd.display(app.evse.info.version, 0, 1, { clear: true, time: 5 * 1000 });
+    });
+
+    app.on("status", (status) => {
+      if(status.hasOwnProperty("ipaddress")) {
+        this.lcd.display("IP Address:", 0, 0, { clear: true });
+        this.lcd.display(status.ipaddress, 0, 1, { clear: true, time: 5 * 1000 });  
+      }
+    });
+  }
+};

--- a/src/lcd.js
+++ b/src/lcd.js
@@ -15,7 +15,7 @@ module.exports = class
     // TODO extend to support different LCD drivers, eg I2C directly
     if("rapi" === driver.toLowerCase()) {
       const lcdDriver = require("./lcdrapi");
-      this.lcd = new lcdDriver();
+      this.lcd = new lcdDriver(app.evse.evseConn);
     } else {
       throw "Unknown LCD driver "+driver;
     }
@@ -28,7 +28,7 @@ module.exports = class
     app.on("status", (status) => {
       if(status.hasOwnProperty("ipaddress")) {
         this.lcd.display("IP Address:", 0, 0, { clear: true });
-        this.lcd.display(status.ipaddress, 0, 1, { clear: true, time: 5 * 1000 });  
+        this.lcd.display(status.ipaddress, 0, 1, { clear: true, time: 5 * 1000 });
       }
     });
   }

--- a/src/lcdrapi.js
+++ b/src/lcdrapi.js
@@ -1,0 +1,17 @@
+/* jshint node: true, esversion: 6*/
+
+"use strict";
+
+const debug = require("debug")("openevse:lcd:rapi");
+
+module.exports = class
+{
+  constructor()
+  {
+  }
+
+  display(message, x, y, options)
+  {
+    debug(message, x, y, options);
+  }
+};

--- a/src/lcdrapi.js
+++ b/src/lcdrapi.js
@@ -4,14 +4,81 @@
 
 const debug = require("debug")("openevse:lcd:rapi");
 
+const LCD_MAX_LEN = 16;
+
 module.exports = class
 {
-  constructor()
+  constructor(openevse)
   {
+    this.openevse = openevse;
+    this.messages = [];
+    this.lcdClaimed = false;
+    this.nextExentTimer = false;
   }
 
   display(message, x, y, options)
   {
-    debug(message, x, y, options);
+    if(options.displayNow) {
+      this.messages = [];
+      if(this.nextExentTimer) {
+        clearTimeout(this.nextExentTimer);
+        this.nextExentTimer = false;
+      }
+    }
+
+    var processNow = false === this.nextExentTimer;
+    debug(message, x, y, options, processNow);
+
+    this.messages.push({
+      message: message,
+      x: x,
+      y: y,
+      options: options
+    });
+
+    if(processNow) {
+      this.process();
+    }
+  }
+
+  clearEndOfLine(x, y, done) {
+    if(x < LCD_MAX_LEN) {
+      this.openevse.lcd_print_text(() => {
+        this.clearEndOfLine(x + 6, y, done);
+      }, x, y, "      ");
+    } else {
+      done();
+    }
+  }
+
+  process()
+  {
+    this.nextExentTimer = false;
+
+    if(this.messages.length > 0)
+    {
+      var msg = this.messages.shift();
+
+      if(false === this.lcdClaimed) {
+        this.openevse.lcd_claim(() => {
+          this.lcdClaimed = true;
+        }, false);
+      }
+
+      this.openevse.lcd_print_text(() => {
+        if(msg.options.clear) {
+          this.clearEndOfLine(msg.x + msg.message.length, msg.y, () => {
+            var nextTime = msg.options.time ? msg.options.time : 0;
+            this.nextExentTimer = setTimeout(this.process.bind(this), nextTime);
+          });
+        }
+      }, msg.x, msg.y, msg.message);
+    }
+    else
+    {
+      this.openevse.lcd_claim(() => {
+        this.lcdClaimed = false;
+      }, false);
+    }
   }
 };

--- a/src/openevsewifi.js
+++ b/src/openevsewifi.js
@@ -66,10 +66,10 @@ module.exports = class OpenEVSEWiFi extends EventEmitter
       },
     };
     this._status = {
-      mode: "STA",
-      wifi_client_connected: 1,
-      srssi: -50,
-      ipaddress: "172.16.0.191",
+      mode: "NA",
+      wifi_client_connected: 0,
+      srssi: 0,
+      ipaddress: "",
       emoncms_connected: 0,
       packets_sent: 0,
       packets_success: 0,

--- a/src/web.js
+++ b/src/web.js
@@ -1,5 +1,7 @@
 /* jshint node: true, esversion: 6*/
 
+"use strict";
+
 const express = require("express");
 const bodyParser = require("body-parser");
 const debug = require("debug")("openevse:wifi:web");


### PR DESCRIPTION
Fixes #8 

This is actually quite a bit of groundwork for future dev as well as displaying the IP on the LCD.

Added the concept of LCD UI that basically sits on top of the app like the Web UI and listens to events from the app and updates the LCD as needed. There is also a split in what should be generic code and display specific stuff, so later the LCD could be driven directly rather than by the OpenEVSE.

The network type and IP are then added to the state of the EVSE module so that can then be picked up not only by the LCD but also by the Web UI.

A boot up message is also displayed.